### PR TITLE
Import last date directly from data

### DIFF
--- a/src/GraphTable.js
+++ b/src/GraphTable.js
@@ -9,10 +9,10 @@ const last = (array) => {
   return array[array.length - 1]
 }
 
-const latestDate = 'April - 2017'
 export default class GraphTable extends PureComponent {
   render() {
     const summary = this.props.summary
+    const latestDate = last(summary.dates)
     const rows = summary.data.map((item) => {
       const sparklineConfig = {
         series: [item],


### PR DESCRIPTION
Fixes #120. This updates to pull last date directly from our data. This is conveniently, already in the format we use.

Tested by running locally and confirming date still worked.