### PR TITLE
Issue 137: Email alert on failure

### DIFF
--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.4",
-    "serial": 15,
+    "serial": 17,
     "lineage": "5b5822db-1d83-13de-76ea-0dd99b442767",
     "modules": [
         {
@@ -10,6 +10,45 @@
             ],
             "outputs": {},
             "resources": {
+                "aws_cloudwatch_metric_alarm.failure": {
+                    "type": "aws_cloudwatch_metric_alarm",
+                    "depends_on": [
+                        "module.email"
+                    ],
+                    "primary": {
+                        "id": "inclucivics_ingest_failure",
+                        "attributes": {
+                            "actions_enabled": "true",
+                            "alarm_actions.#": "1",
+                            "alarm_actions.3866892562": "arn:aws:sns:us-east-1:605366678235:inclucivics-ingest-email-EmailSNSTopic-10PQOZULTIXGP",
+                            "alarm_description": "Send an email when the lambda function ends in an Error",
+                            "alarm_name": "inclucivics_ingest_failure",
+                            "comparison_operator": "GreaterThanThreshold",
+                            "datapoints_to_alarm": "0",
+                            "dimensions.%": "1",
+                            "dimensions.FunctionName": "inclucivics_ingest",
+                            "evaluate_low_sample_count_percentiles": "",
+                            "evaluation_periods": "1",
+                            "extended_statistic": "",
+                            "id": "inclucivics_ingest_failure",
+                            "insufficient_data_actions.#": "0",
+                            "metric_name": "Errors",
+                            "namespace": "AWS/Lambda",
+                            "ok_actions.#": "0",
+                            "period": "300",
+                            "statistic": "SampleCount",
+                            "threshold": "0",
+                            "treat_missing_data": "missing",
+                            "unit": ""
+                        },
+                        "meta": {
+                            "schema_version": "1"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
                 "aws_s3_bucket.data": {
                     "type": "aws_s3_bucket",
                     "depends_on": [],
@@ -54,13 +93,13 @@
                     "type": "archive_file",
                     "depends_on": [],
                     "primary": {
-                        "id": "1d41f4a581a3683370ed12b34bd89e821daf7e7d",
+                        "id": "7f8b51aaaa8dffc600fb06e7898421c13720be56",
                         "attributes": {
-                            "id": "1d41f4a581a3683370ed12b34bd89e821daf7e7d",
-                            "output_base64sha256": "Q9L4LxV7mYQRYX87bbVsgCkWudjUXpC2XWHCUDhKy4w=",
-                            "output_md5": "5a71bc3691400e3f71dec20df7910893",
+                            "id": "7f8b51aaaa8dffc600fb06e7898421c13720be56",
+                            "output_base64sha256": "L+lpsFsBk21+Ik2cg/aK673Flic8Vmce7jCdzkS0Oxc=",
+                            "output_md5": "75fcec81a8b0c0efae6e6c125dec0c20",
                             "output_path": "ingest.zip",
-                            "output_sha": "1d41f4a581a3683370ed12b34bd89e821daf7e7d",
+                            "output_sha": "7f8b51aaaa8dffc600fb06e7898421c13720be56",
                             "output_size": "5491771",
                             "source.#": "0",
                             "source_dir": "ingest",
@@ -101,6 +140,73 @@
                     },
                     "deposed": [],
                     "provider": "provider.aws"
+                }
+            },
+            "depends_on": []
+        },
+        {
+            "path": [
+                "root",
+                "email"
+            ],
+            "outputs": {
+                "arn": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "arn:aws:sns:us-east-1:605366678235:inclucivics-ingest-email-EmailSNSTopic-10PQOZULTIXGP"
+                }
+            },
+            "resources": {
+                "aws_cloudformation_stack.sns-topic": {
+                    "type": "aws_cloudformation_stack",
+                    "depends_on": [
+                        "data.template_file.cloudformation_sns_stack"
+                    ],
+                    "primary": {
+                        "id": "arn:aws:cloudformation:us-east-1:605366678235:stack/inclucivics-ingest-email/c7f07470-2b07-11e8-b302-50fae98974c5",
+                        "attributes": {
+                            "disable_rollback": "false",
+                            "iam_role_arn": "",
+                            "id": "arn:aws:cloudformation:us-east-1:605366678235:stack/inclucivics-ingest-email/c7f07470-2b07-11e8-b302-50fae98974c5",
+                            "name": "inclucivics-ingest-email",
+                            "outputs.%": "1",
+                            "outputs.ARN": "arn:aws:sns:us-east-1:605366678235:inclucivics-ingest-email-EmailSNSTopic-10PQOZULTIXGP",
+                            "parameters.%": "0",
+                            "tags.%": "1",
+                            "tags.Owner": "Max Shenfield",
+                            "template_body": "{\"AWSTemplateFormatVersion\":\"2010-09-09\",\"Outputs\":{\"ARN\":{\"Description\":\"Email SNS Topic ARN\",\"Value\":{\"Ref\":\"EmailSNSTopic\"}}},\"Resources\":{\"EmailSNSTopic\":{\"Properties\":{\"DisplayName\":\"Inclucivics Ingest Email\",\"Subscription\":[{\"Endpoint\":\"max@codefornashville.org\",\"Protocol\":\"email\"}]},\"Type\":\"AWS::SNS::Topic\"}}}"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 1800000000000,
+                                "delete": 1800000000000,
+                                "update": 1800000000000
+                            }
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "data.template_file.cloudformation_sns_stack": {
+                    "type": "template_file",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "47acbc333acc5ef711a8c34c624ae67c244d31c60e975e58121dc134ba306243",
+                        "attributes": {
+                            "id": "47acbc333acc5ef711a8c34c624ae67c244d31c60e975e58121dc134ba306243",
+                            "rendered": "{\n  \"AWSTemplateFormatVersion\": \"2010-09-09\",\n\n  \"Resources\" : {\n    \"EmailSNSTopic\": {\n      \"Type\" : \"AWS::SNS::Topic\",\n      \"Properties\" : {\n        \"DisplayName\" : \"Inclucivics Ingest Email\",\n        \"Subscription\": [\n          {\n           \"Endpoint\" : \"max@codefornashville.org\",\n           \"Protocol\" : \"email\"\n          }\n        ]\n      }\n    }\n  },\n\n  \"Outputs\" : {\n    \"ARN\" : {\n      \"Description\" : \"Email SNS Topic ARN\",\n      \"Value\" : { \"Ref\" : \"EmailSNSTopic\" }\n    }\n  }\n}\n",
+                            "template": "{\n  \"AWSTemplateFormatVersion\": \"2010-09-09\",\n\n  \"Resources\" : {\n    \"EmailSNSTopic\": {\n      \"Type\" : \"AWS::SNS::Topic\",\n      \"Properties\" : {\n        \"DisplayName\" : \"${display_name}\",\n        \"Subscription\": [\n          {\n           \"Endpoint\" : \"${email_address}\",\n           \"Protocol\" : \"${protocol}\"\n          }\n        ]\n      }\n    }\n  },\n\n  \"Outputs\" : {\n    \"ARN\" : {\n      \"Description\" : \"Email SNS Topic ARN\",\n      \"Value\" : { \"Ref\" : \"EmailSNSTopic\" }\n    }\n  }\n}\n",
+                            "vars.%": "3",
+                            "vars.display_name": "Inclucivics Ingest Email",
+                            "vars.email_address": "max@codefornashville.org",
+                            "vars.protocol": "email"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.template"
                 }
             },
             "depends_on": []
@@ -229,16 +335,16 @@
                             "id": "inclucivics_ingest",
                             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:605366678235:function:inclucivics_ingest/invocations",
                             "kms_key_arn": "",
-                            "last_modified": "2018-03-18T22:57:33.863+0000",
+                            "last_modified": "2018-03-18T23:55:10.981+0000",
                             "memory_size": "128",
                             "publish": "false",
                             "qualified_arn": "arn:aws:lambda:us-east-1:605366678235:function:inclucivics_ingest:$LATEST",
                             "reserved_concurrent_executions": "0",
                             "role": "arn:aws:iam::605366678235:role/inclucivics_ingest",
                             "runtime": "nodejs6.10",
-                            "source_code_hash": "Q9L4LxV7mYQRYX87bbVsgCkWudjUXpC2XWHCUDhKy4w=",
+                            "source_code_hash": "L+lpsFsBk21+Ik2cg/aK673Flic8Vmce7jCdzkS0Oxc=",
                             "tags.%": "0",
-                            "timeout": "200",
+                            "timeout": "60",
                             "tracing_config.#": "1",
                             "tracing_config.0.mode": "PassThrough",
                             "version": "$LATEST",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,4 @@
+# Here so it can be re-used
+variable "lambda_name" {
+  default = "inclucivics_ingest"
+}


### PR DESCRIPTION
Closes #137.  This sends an email alert when any failure of the scheduled ingestion occurs.

This is hardcoded to my email address. Ideally it would be something like "ops@codefornashville.org", but I'm not sure exactly how to do that now.

This moves the lambda name to a variable, only so that it can be re-used. It isn't in the [`aws_lambda_function`](https://www.terraform.io/docs/providers/aws/r/lambda_function.html)