### PR TITLE
Issue 147 latest date renders incorrectly

### DIFF
--- a/src/SummaryCharts.js
+++ b/src/SummaryCharts.js
@@ -17,7 +17,9 @@ export default class SummaryCharts extends PureComponent {
       .then(res => res.json())
       .then(summaries => {
         summaries.forEach(s => {
-          s.date = new Date(s.date)
+          let [year, month, day] = s.date.split("-").map((x) => parseInt(x))
+          // Need to subtract 1 because Date's month field is 0 based
+          s.date = new Date(year, month - 1, day)
         })
         return summaries
       })

--- a/terraform/ingest/index.js
+++ b/terraform/ingest/index.js
@@ -120,8 +120,11 @@ function processFiles () {
   filenames.forEach(f => {
     // YYYYMMDD format
     let date = f.replace('.csv', '')
+    let re = /(?<year>\d{4})-*(?<month>\d{2})-*(?<day>\d{2})/
+    let {groups: {day, month, year}} = re.exec(date)
+
     // Since we end up sending this to the frontend, make it parseable upfront
-    date = `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`
+    date = `${day}-${month}-${year}`
 
     const blob = fs.readFileSync(`/tmp/input/${f}`, 'utf8')
     const lines = csvParse(blob)


### PR DESCRIPTION
Renders newest date correctly, addressing bug in #147 and uses regex to parse incoming dates to be stored in S3 summaries as referenced in #153 