### PR TITLE
copy cname record from gh-pages so it isn't overwritten with each deploy

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+inclucivics.org


### PR DESCRIPTION
Just noticed that when we change the custom domain, github adds a commit with the CNAME to the gh-pages branch, but when we redeploy from `master`, that file is dropped. I think that's related to the fact that we lost the website at inclucivics.org this week. So, that's fixed, but I still don't know why it won't work at www.inclucivics.org.