### PR TITLE
make sure to copy CNAME into build for github pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node-fetch": "^2.6.0"
   },
   "scripts": {
-    "build": "react-scripts build",
+    "build": "react-scripts build && cp CNAME build",
     "deploy": "gh-pages -d build",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",


### PR DESCRIPTION
Without this, we get a 404 that there is no github pages project at this location. That's because it doesn't recognize its CNAME as inclucivics.org. This is the same file github will create if you set a custom domain for the repo online, but it will only create it in the default github pages branch. But, we don't merge the master branch into our gh-pages branch. In fact, we use the gh-pages node module from the master branch to rebase the gh-pages branch with only the build artifacts. So, we needed a step that manually puts the CNAME in the build artifacts.