### PR TITLE
linting according to yarn test command

### DIFF
--- a/scripts/data-fetch.js
+++ b/scripts/data-fetch.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const fetch = require('node-fetch');
-const https = require('https');
+const fs = require('fs')
+const fetch = require('node-fetch')
+const https = require('https')
 
 /**
  * Fetches all of the data files stored on the Code For Nashville
@@ -11,33 +11,32 @@ const https = require('https');
  */
 
 const fetchPublishedData = async () => {
-    const httpsAgent = https.Agent({
-        rejectUnauthorized: false,
-        requestCert: false
-    });
-    
-    const options = {
-        agent: httpsAgent
-    }
-        ,apiEndpoint = 'https://api.github.com/repos'
-        ,repoAddress = '/code-for-nashville/open-data-portal'
-        ,path = '/nashville/metro-general-government-employees-demographic-data/renamed-csv';
-    
-    let res = await fetch(apiEndpoint + repoAddress + '/contents' + path, options);
-    let resolved = await res.ok;
-    if (resolved) {
-        let fileList = await res.json();
-        fileList.map(async x => {
-            let rows = await fetch(x.download_url, options);
-            let data = await rows.text();
-            var filename = x.name.replace(/-/g, '').slice(0, 6) + '01';
-            fs.writeFileSync(`./input/${filename}.csv`, data);
-        });
-    } else {
-        console.log('ERROR: ');
-        console.log(await res.statusText);
-    };
+  const httpsAgent = https.Agent({
+    rejectUnauthorized: false,
+    requestCert: false
+  })
 
-};
+  const options = {
+    agent: httpsAgent
+  }
+  const apiEndpoint = 'https://api.github.com/repos'
+  const repoAddress = '/code-for-nashville/open-data-portal'
+  const path = '/nashville/metro-general-government-employees-demographic-data/renamed-csv'
 
-fetchPublishedData();
+  let res = await fetch(apiEndpoint + repoAddress + '/contents' + path, options)
+  let resolved = await res.ok
+  if (resolved) {
+    let fileList = await res.json()
+    fileList.map(async x => {
+      let rows = await fetch(x.download_url, options)
+      let data = await rows.text()
+      var filename = x.name.replace(/-/g, '').slice(0, 6) + '01'
+      fs.writeFileSync(`./input/${filename}.csv`, data)
+    })
+  } else {
+    console.log('ERROR: ')
+    console.log(await res.statusText)
+  };
+}
+
+fetchPublishedData()

--- a/scripts/data-import.js
+++ b/scripts/data-import.js
@@ -88,7 +88,7 @@ function employeeFromCSVLine (employee) {
   const salaryBucketId = bucketSalary(salary)
   // store the regex to find either Dept or Department in the keys of the
   // employee object that's passed in to this function (i flag allows regex to ignore case)
-  const dept_regex = /DEPT|DEPARTMENT/gi
+  const deptRegex = /DEPT|DEPARTMENT/gi
 
   // filter through the keys of the employee object to find the column
   // that contains the name of the department
@@ -97,14 +97,14 @@ function employeeFromCSVLine (employee) {
   // if the column contains letter and not just numbers.  In some of the older
   // files, there are two department columns, one with a number, and one with the name
   // for this purpose we just want the name of the department
-  let department_name = employee[Object.keys(employee)
-                                .filter(k => k.match(dept_regex) != null)
+  let departmentName = employee[Object.keys(employee)
+                                .filter(k => k.match(deptRegex) != null)
                                 .filter(l => employee[l].match(/[a-z]+/gi) != null)]
 
   return {
     ethnicityId: parseInt(employee['Ethnic Code']),
     salaryBucketId,
-    departmentId: getDepartmentId(department_name),
+    departmentId: getDepartmentId(departmentName),
     gender: employee['Gender']
   }
 }

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -22,7 +22,7 @@ class Nav extends Component {
           <a className={aboutClass} onClick={this.toggleAbout}>
             Analyzing the demographic makeup of 50 Metro Nashville departments
           </a>
-          <button className='navbar-expand' onClick={this.toggleAbout}></button>
+          <button className='navbar-expand' onClick={this.toggleAbout} />
           {about}
         </div>
       </nav>


### PR DESCRIPTION
@kazshak, FYI, here are additional changes recommended by our linter:
```~/src/code-for-nashville/inclucivics$ yarnpkg test                      
yarn run v1.13.0                                                                                                  
$ yarn standard && react-scripts test --env=jsdom                                                                          
$ /home/qwelk/src/code-for-nashville/inclucivics/node_modules/.bin/standard                                                                  
standard: Use JavaScript Standard Style (https://standardjs.com)                                                           
  /home/qwelk/src/code-for-nashville/inclucivics/scripts/data-fetch.js:19:3: Split initialized 'const' declarations into multiple statements.
  /home/qwelk/src/code-for-nashville/inclucivics/scripts/data-import.js:91:9: Identifier 'dept_regex' is not in camel case.
  /home/qwelk/src/code-for-nashville/inclucivics/scripts/data-import.js:100:7: Identifier 'department_name' is not in camel case.
  /home/qwelk/src/code-for-nashville/inclucivics/scripts/data-import.js:100:25: Expected "[" and "]" to be on the same line
error Command failed with exit code 1.                                                        
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.        
error Command failed with exit code 1.                                                      
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.   ```

But I implemented them, so it passes now.