### PR TITLE
Update analytics to Global Site Tag (gtag.js)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,15 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>IncluCivics</title>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-74QEPWXNZS"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-74QEPWXNZS');
+</script>
     <style>
     .loading {
       position: absolute;
@@ -62,16 +71,5 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      // create-react-app populated strings wrapped in % with environment variables of that name
-      // the production build will optimize this conditional away
-      if ('%NODE_ENV%' === 'production') {
-        ga('create','UA-100810945-1','auto');ga('send','pageview');
-      }
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Removing the previous analytics verification to use a Global Site Tag (gtag.js) and have it associated with the wesley@codefornashville.org account.